### PR TITLE
One of the tests could be written better.

### DIFF
--- a/bin/move
+++ b/bin/move
@@ -1,5 +1,14 @@
 #!/usr/bin/env ruby
 
 require_relative '../lib/move.rb'
-
-# Code your CLI Here
+board = [" ", " ", " ", " ", " ", " ", " ", " ", " "]
+puts "Welcome to Tic Tac Toe!"
+  puts " #{board[0]} | #{board[1]} | #{board[2]} "
+  puts "-----------"
+  puts " #{board[3]} | #{board[4]} | #{board[5]} "
+  puts "-----------"
+  puts " #{board[6]} | #{board[7]} | #{board[8]} "
+puts "Where would you like to go?"
+input = gets.strip
+move(board, input)
+display_board(board)

--- a/lib/move.rb
+++ b/lib/move.rb
@@ -1,4 +1,4 @@
-def display_board(board)
+def display_board(board=[" "," "," "," "," "," "," "," "," "])
   puts " #{board[0]} | #{board[1]} | #{board[2]} "
   puts "-----------"
   puts " #{board[3]} | #{board[4]} | #{board[5]} "
@@ -7,7 +7,7 @@ def display_board(board)
 end
 
 # code your move method here!
-def move(board, position, placeholder='X')
-  board[position-1] = placeholder
-  display_board(board)
+def move(board, input, placeholder='X')
+  board[input.to_i-1] = placeholder
+  board
 end

--- a/lib/move.rb
+++ b/lib/move.rb
@@ -7,3 +7,7 @@ def display_board(board)
 end
 
 # code your move method here!
+def move(board, position, placeholder='X')
+  board[position-1] = placeholder
+  display_board(board)
+end


### PR DESCRIPTION
I wanted to print the board before prompting the user for their move (makes sense, don't you think?) but the test on line 49 of the 02_cli_spec.rb file was tricked by this:

it 'calls display_board passing the modified board' do
    allow($stdout).to receive(:puts)

    allow(self).to receive(:gets).and_return('1')
    expect(self).to receive(:display_board).with(["X", " ", " ", " ", " ", " ", " ", " ", " "])

    run_file("./bin/move")
  end

It read my first call to display_board(board) and said that I wasn't passing the modified board to the display_board method, when in fact I was doing so farther down in the script:

#!/usr/bin/env ruby

require_relative '../lib/move.rb'
board = [" ", " ", " ", " ", " ", " ", " ", " ", " "]
puts "Welcome to Tic Tac Toe!"
display_board(board)
puts "Where would you like to go?"
input = gets.strip
move(board, input)
display_board(board)

This seems to me to be a more desirable behavior as we'll be looping the last 4 lines of the script to complete the game and each one will have the current board printed out before the user has to make a move.